### PR TITLE
Fix import

### DIFF
--- a/ZLSinusWaveView/ZLSinusWaveView.h
+++ b/ZLSinusWaveView/ZLSinusWaveView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Syed Haris Ali. All rights reserved.
 //
 
-#import "EZAudioPlot.h"
+#import "EZAudio/EZAudioPlot.h"
 
 @interface ZLSinusWaveView : EZAudioPlot
 


### PR DESCRIPTION
**Disclaimer:** I've been doing iOS for a grand total of three days and I'm really, really bad at it.

Having installed EZAudio with cocoapods, this line was failing with `'EZAudioPlot.h' file not found`. Upon changing it from `#import "EZAudioPlot.h"` to `#import "EZAudio/EZAudioPlot.h"`, it builds fine.
